### PR TITLE
Refactoring skip_checks for specific contrail version

### DIFF
--- a/tungsten_tempest_plugin/tests/api/contrail/rbac_base.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/rbac_base.py
@@ -100,9 +100,21 @@ CONF = config.CONF
 LOG = logging.getLogger(__name__)
 
 
+def get_contail_version():
+    return float(CONF.sdn.contrail_version)
+
+
 class BaseContrailTest(rbac_utils.RbacUtilsMixin, test.BaseTestCase):
     """Base class for Contrail tests."""
     credentials = ['primary', 'admin']
+
+    required_contrail_version = None
+
+    @classmethod
+    def skip_if_contrail_version_less(cls, version):
+        if get_contail_version() < version:
+            msg = "The tests require Contrail >= %s" % version
+            raise cls.skipException(msg)
 
     @classmethod
     def skip_checks(cls):
@@ -115,6 +127,8 @@ class BaseContrailTest(rbac_utils.RbacUtilsMixin, test.BaseTestCase):
         if CONF.auth.tempest_roles != ['admin']:
             raise cls.skipException(
                 "%s skipped because tempest roles is not admin" % cls.__name__)
+        if cls.required_contrail_version:
+            cls.skip_if_contrail_version_less(cls.required_contrail_version)
 
     @classmethod
     def setup_clients(cls):

--- a/tungsten_tempest_plugin/tests/api/contrail/test_config_client.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_config_client.py
@@ -45,7 +45,7 @@ class ConfigNodeTest(rbac_base.BaseContrailTest):
     def _create_config_node(self):
         config_node_ip_address = self._random_ip_generator()
         display_name = data_utils.rand_name('config_node')
-        if float(CONF.sdn.contrail_version) < 5:
+        if rbac_base.get_contail_version() < 5:
             fq_name = [display_name]
         else:
             fq_name = ['default-global-system-config', display_name]
@@ -200,7 +200,7 @@ class GlobalSystemConfigTest(rbac_base.BaseContrailTest):
         with self.rbac_utils.override_role(self):
             self.config_client.list_global_system_configs()
 
-    @testtools.skipUnless(float(CONF.sdn.contrail_version) < 5,
+    @testtools.skipUnless(rbac_base.get_contail_version() < 5,
                           'Not supported in OpenContrail versions >= 5')
     @rbac_rule_validation.action(service="Contrail",
                                  rules=["create_global_system_configs"])
@@ -214,7 +214,7 @@ class GlobalSystemConfigTest(rbac_base.BaseContrailTest):
                                  rules=["show_global_system_config"])
     @decorators.idempotent_id('4b9f9131-cb34-4b7d-9d06-c6aca85cce3a')
     def test_show_global_system_config(self):
-        if float(CONF.sdn.contrail_version) < 5:
+        if rbac_base.get_contail_version() < 5:
             new_config = self._create_global_system_config()
             with self.rbac_utils.override_role(self):
                 self.config_client.show_global_system_config(
@@ -236,7 +236,7 @@ class GlobalSystemConfigTest(rbac_base.BaseContrailTest):
                         self.config_client.show_global_system_config(
                             gsc['uuid'])
 
-    @testtools.skipUnless(float(CONF.sdn.contrail_version) < 5,
+    @testtools.skipUnless(rbac_base.get_contail_version() < 5,
                           'Not supported in OpenContrail versions >= 5')
     @rbac_rule_validation.action(service="Contrail",
                                  rules=["update_global_system_config"])
@@ -250,7 +250,7 @@ class GlobalSystemConfigTest(rbac_base.BaseContrailTest):
                 new_config['uuid'],
                 display_name=update_name)
 
-    @testtools.skipUnless(float(CONF.sdn.contrail_version) < 5,
+    @testtools.skipUnless(rbac_base.get_contail_version() < 5,
                           'Not supported in OpenContrail versions >= 5')
     @rbac_rule_validation.action(service="Contrail",
                                  rules=["delete_global_system_config"])

--- a/tungsten_tempest_plugin/tests/api/contrail/test_fabric.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_fabric.py
@@ -25,11 +25,7 @@ CONF = config.CONF
 
 class FabricContrailTest(rbac_base.BaseContrailTest):
 
-    @classmethod
-    def skip_checks(cls):
-        super(FabricContrailTest, cls).skip_checks()
-        if float(CONF.sdn.contrail_version) < 5:
-            raise cls.skipException("fabric requires Contrail >= 5")
+    required_contrail_version = 5
 
     @classmethod
     def resource_setup(cls):

--- a/tungsten_tempest_plugin/tests/api/contrail/test_fabric_namespaces.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_fabric_namespaces.py
@@ -25,11 +25,7 @@ CONF = config.CONF
 
 class FabricNamespacesContrailTest(rbac_base.BaseContrailTest):
 
-    @classmethod
-    def skip_checks(cls):
-        super(FabricNamespacesContrailTest, cls).skip_checks()
-        if float(CONF.sdn.contrail_version) < 5:
-            raise cls.skipException("fabric-namespace requires Contrail >= 5")
+    required_contrail_version = 5
 
     @classmethod
     def resource_setup(cls):

--- a/tungsten_tempest_plugin/tests/api/contrail/test_qos_queue.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_qos_queue.py
@@ -37,7 +37,7 @@ class QosQueueContrailTest(rbac_base.BaseContrailTest):
 
     def _create_qos_queues(self):
         name = data_utils.rand_name('test-rbac-qos-queue')
-        if float(CONF.sdn.contrail_version) < 5:
+        if rbac_base.get_contail_version() < 5:
             fq_name = [name]
         else:
             fq_name = ['default-global-system-config',


### PR DESCRIPTION
Add `required_contrail_version` variable to BaseContrailTest class to skip
tests if version of Contrail in config file less than required.