### PR TITLE
Fix using rbac utils

### DIFF
--- a/tungsten_tempest_plugin/tests/api/contrail/rbac_base.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/rbac_base.py
@@ -137,7 +137,6 @@ class BaseContrailTest(rbac_utils.RbacUtilsMixin, test.BaseTestCase):
         cls.admin_client = cls.os_admin.networks_client
         dscv = CONF.identity.disable_ssl_certificate_validation
         ca_certs = CONF.identity.ca_certificates_file
-        cls.setup_rbac_utils()
 
         cls.access_control_client = AccessControlClient(
             cls.auth_provider,

--- a/tungsten_tempest_plugin/tests/api/contrail/test_access_control.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_access_control.py
@@ -78,7 +78,7 @@ class AccessControlTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('2bfde8fd-36fe-4e69-ba59-6f2db8941e7d')
     def test_list_api_access_lists(self):
         """test method for list api access list"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.access_control_client.list_api_access_lists()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -86,7 +86,7 @@ class AccessControlTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('b2b5f50c-07d8-4d79-b9a4-78187ad97353')
     def test_create_api_access_lists(self):
         """test method for create api access list"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_api_access_lists()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -95,7 +95,7 @@ class AccessControlTest(rbac_base.BaseContrailTest):
     def test_show_api_access_list(self):
         """test method for show api access list"""
         new_api_list = self._create_api_access_lists()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.access_control_client.show_api_access_list(
                 new_api_list['uuid'])
 
@@ -106,7 +106,7 @@ class AccessControlTest(rbac_base.BaseContrailTest):
         """test method for update api access list"""
         new_api_list = self._create_api_access_lists()
         update_name = data_utils.rand_name('test')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.access_control_client.update_api_access_list(
                 new_api_list['uuid'],
                 display_name=update_name)
@@ -117,7 +117,7 @@ class AccessControlTest(rbac_base.BaseContrailTest):
     def test_delete_api_access_list(self):
         """test method for delete api access list"""
         new_api_list = self._create_api_access_lists()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.access_control_client.delete_api_access_list(
                 new_api_list['uuid'])
 
@@ -126,7 +126,7 @@ class AccessControlTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('c56a1338-a9d1-4286-8aeb-3a0d60d93037')
     def test_list_access_control_lists(self):
         """test method for list access control list"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.access_control_client.list_access_control_lists()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -136,7 +136,7 @@ class AccessControlTest(rbac_base.BaseContrailTest):
         """test method for create access control list"""
         # Create Security Group
         sec_group = self._create_security_groups()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_access_control_lists(sec_group['name'])
 
     @rbac_rule_validation.action(service="Contrail",
@@ -148,7 +148,7 @@ class AccessControlTest(rbac_base.BaseContrailTest):
         sec_group = self._create_security_groups()
         new_ctrl_list = self._create_access_control_lists(
             sec_group['name'])
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.access_control_client.show_access_control_list(
                 new_ctrl_list['uuid'])
 
@@ -161,7 +161,7 @@ class AccessControlTest(rbac_base.BaseContrailTest):
         new_ctrl_list = self._create_access_control_lists(
             sec_group['name'])
         update_name = data_utils.rand_name('test')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.access_control_client.update_access_control_list(
                 new_ctrl_list['uuid'],
                 display_name=update_name)
@@ -175,6 +175,6 @@ class AccessControlTest(rbac_base.BaseContrailTest):
         sec_group = self._create_security_groups()
         new_ctrl_list = self._create_access_control_lists(
             sec_group['name'])
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.access_control_client.delete_access_control_list(
                 new_ctrl_list['uuid'])

--- a/tungsten_tempest_plugin/tests/api/contrail/test_alarm.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_alarm.py
@@ -74,7 +74,7 @@ class AlarmContrailTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('dc7d19dd-dd5e-4ec8-bf0c-c6d9d83a60a8')
     def test_list_alarms(self):
         """test method for list alarms"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.alarm_client.list_alarms()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -82,7 +82,7 @@ class AlarmContrailTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('7fe55d0c-e54a-4bb7-95a6-9c53f9e9c4bf')
     def test_create_alarms(self):
         """test method for create alarms"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_alarm()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -91,7 +91,7 @@ class AlarmContrailTest(rbac_base.BaseContrailTest):
     def test_show_alarm(self):
         """test method for show alarms"""
         alarm_uuid = self._create_alarm()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.alarm_client.show_alarm(alarm_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -100,7 +100,7 @@ class AlarmContrailTest(rbac_base.BaseContrailTest):
     def test_update_alarm(self):
         """test method for update alarms"""
         alarm_uuid = self._create_alarm()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._update_alarm(alarm_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -110,5 +110,5 @@ class AlarmContrailTest(rbac_base.BaseContrailTest):
         """test method for delete alarms"""
         # Create global system config
         alarm_uuid = self._create_alarm()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.alarm_client.delete_alarm(alarm_uuid)

--- a/tungsten_tempest_plugin/tests/api/contrail/test_alias_ip.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_alias_ip.py
@@ -116,7 +116,7 @@ class AliasIPsTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('899d6824-0755-41ef-adef-03eb1858bcb0')
     def test_list_alias_ips(self):
         """test method for list alias IP"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.alias_ip_client.list_alias_ips()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -125,7 +125,7 @@ class AliasIPsTest(rbac_base.BaseContrailTest):
     def test_create_alias_ips(self):
         """test method for create alias IP"""
         new_alias_ip_pool = self._create_alias_ip_pools()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_alias_ips(new_alias_ip_pool, '2.2.3.1')
 
     @rbac_rule_validation.action(service="Contrail",
@@ -135,7 +135,7 @@ class AliasIPsTest(rbac_base.BaseContrailTest):
         """test method for show alias IP"""
         new_alias_ip_pool = self._create_alias_ip_pools()
         new_alias_ip = self._create_alias_ips(new_alias_ip_pool, '2.2.3.2')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.alias_ip_client.show_alias_ip(
                 new_alias_ip['uuid'])
 
@@ -147,7 +147,7 @@ class AliasIPsTest(rbac_base.BaseContrailTest):
         new_alias_ip_pool = self._create_alias_ip_pools()
         new_alias_ip = self._create_alias_ips(new_alias_ip_pool, '2.2.3.3')
         update_name = data_utils.rand_name('test')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.alias_ip_client.update_alias_ip(
                 new_alias_ip['uuid'],
                 display_name=update_name)
@@ -159,7 +159,7 @@ class AliasIPsTest(rbac_base.BaseContrailTest):
         """test method for delete alias IP"""
         new_alias_ip_pool = self._create_alias_ip_pools()
         new_alias_ip = self._create_alias_ips(new_alias_ip_pool, '2.2.3.4')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.alias_ip_client.delete_alias_ip(
                 new_alias_ip['uuid'])
 
@@ -168,7 +168,7 @@ class AliasIPsTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('ffe85f35-589a-4b90-a1d3-6aed92a85954')
     def test_list_alias_ip_pools(self):
         """est method for list alias IP pools"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.alias_ip_client.list_alias_ip_pools()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -176,7 +176,7 @@ class AliasIPsTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('83abd2c0-d46a-4337-87d0-31cdb86e4226')
     def test_create_alias_ip_pools(self):
         """test method for create alias IP pool"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_alias_ip_pools()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -185,7 +185,7 @@ class AliasIPsTest(rbac_base.BaseContrailTest):
     def test_show_alias_ip_pool(self):
         """test method for show alias IP pool"""
         new_alias_ip_pool = self._create_alias_ip_pools()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.alias_ip_client.show_alias_ip_pool(
                 new_alias_ip_pool['uuid'])
 
@@ -196,7 +196,7 @@ class AliasIPsTest(rbac_base.BaseContrailTest):
         """test method for update alias IP pool"""
         new_alias_ip_pool = self._create_alias_ip_pools()
         update_name = data_utils.rand_name('test')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.alias_ip_client.update_alias_ip_pool(
                 new_alias_ip_pool['uuid'],
                 display_name=update_name)
@@ -207,6 +207,6 @@ class AliasIPsTest(rbac_base.BaseContrailTest):
     def test_delete_alias_ip_pool(self):
         """test method for delete alias IP pool"""
         new_alias_ip_pool = self._create_alias_ip_pools()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.alias_ip_client.delete_alias_ip_pool(
                 new_alias_ip_pool['uuid'])

--- a/tungsten_tempest_plugin/tests/api/contrail/test_analytics_node.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_analytics_node.py
@@ -50,7 +50,7 @@ class ContrailAnalyticsNodeTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('d3002e37-4b42-446d-b144-1b53f0dadfd3')
     def test_list_analytics_nodes(self):
         """test method for list analytics nodes"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.analytics_node_client.list_analytics_nodes()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -59,7 +59,7 @@ class ContrailAnalyticsNodeTest(rbac_base.BaseContrailTest):
     def test_show_analytics_node(self):
         """test method for show analytics nodes"""
         new_node = self._create_analytics_node()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.analytics_node_client.show_analytics_node(new_node['uuid'])
 
     @rbac_rule_validation.action(service="Contrail",
@@ -67,7 +67,7 @@ class ContrailAnalyticsNodeTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('c57482c9-fcb4-4f41-95b0-7f0ffeee3dc3')
     def test_create_analytics_nodes(self):
         """test method for create analytics nodes"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_analytics_node()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -77,7 +77,7 @@ class ContrailAnalyticsNodeTest(rbac_base.BaseContrailTest):
         """test method for update analytics nodes"""
         new_node = self._create_analytics_node()
         update_name = data_utils.rand_name('updated_node')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.analytics_node_client.update_analytics_node(
                 new_node['uuid'], display_name=update_name)
 
@@ -87,5 +87,5 @@ class ContrailAnalyticsNodeTest(rbac_base.BaseContrailTest):
     def test_delete_analytics_node(self):
         """test method for delete analytics nodes"""
         new_node = self._create_analytics_node()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.analytics_node_client.delete_analytics_node(new_node['uuid'])

--- a/tungsten_tempest_plugin/tests/api/contrail/test_attachments_client.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_attachments_client.py
@@ -61,7 +61,7 @@ class AttachmentsClientTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('961dbf54-ae4f-42e8-9d27-69fa7df39013')
     def test_list_provider_attachments(self):
         """test method for list provider attachment objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.attachments_client.list_provider_attachments()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -69,7 +69,7 @@ class AttachmentsClientTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('73ad032e-3e81-4dcc-be55-1987484207cd')
     def test_create_providerattach(self):
         """test method for create provider attachment objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_provider_attachments()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -78,7 +78,7 @@ class AttachmentsClientTest(rbac_base.BaseContrailTest):
     def test_show_provider_attachment(self):
         """test method for delete provider attachment objects"""
         new_provider = self._create_provider_attachments()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.attachments_client.show_provider_attachment(
                 new_provider['uuid'])
 
@@ -89,7 +89,7 @@ class AttachmentsClientTest(rbac_base.BaseContrailTest):
         """test method for update provider attachment objects"""
         new_provider = self._create_provider_attachments()
         update_name = data_utils.rand_name('test')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.attachments_client.update_provider_attachment(
                 new_provider['uuid'],
                 display_name=update_name)
@@ -100,7 +100,7 @@ class AttachmentsClientTest(rbac_base.BaseContrailTest):
     def test_delete_provider_attachment(self):
         """test method for delete provider attachment objects"""
         new_provider = self._create_provider_attachments()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.attachments_client.delete_provider_attachment(
                 new_provider['uuid'])
 
@@ -109,7 +109,7 @@ class AttachmentsClientTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('3eca8fd8-ec3c-4a0e-8f62-b15d28796b7f')
     def test_list_customer_attachments(self):
         """test method for list customer attachment objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.attachments_client.list_customer_attachments()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -117,7 +117,7 @@ class AttachmentsClientTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('53f93053-554c-4202-b763-0230d9a0553a')
     def test_create_customerattachments(self):
         """test method for create customer attachment objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_customer_attachments()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -126,7 +126,7 @@ class AttachmentsClientTest(rbac_base.BaseContrailTest):
     def test_show_customer_attachment(self):
         """test method for show customer attachment objects"""
         new_customer = self._create_customer_attachments()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.attachments_client.show_customer_attachment(
                 new_customer['uuid'])
 
@@ -137,7 +137,7 @@ class AttachmentsClientTest(rbac_base.BaseContrailTest):
         """test method for update customer attachment objects"""
         new_customer = self._create_customer_attachments()
         update_name = data_utils.rand_name('test')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.attachments_client.update_customer_attachment(
                 new_customer['uuid'],
                 display_name=update_name)
@@ -148,6 +148,6 @@ class AttachmentsClientTest(rbac_base.BaseContrailTest):
     def test_delete_customer_attachment(self):
         """test method for delete customer attachment objects"""
         new_customer = self._create_customer_attachments()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.attachments_client.delete_customer_attachment(
                 new_customer['uuid'])

--- a/tungsten_tempest_plugin/tests/api/contrail/test_bgp_as_a_service.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_bgp_as_a_service.py
@@ -46,7 +46,7 @@ class BGPAsAServicesTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('d3153cd0-379e-4e62-9780-ef237e567fc5')
     def test_list_bgp_as_a_services(self):
         """test method for list bgp as a service objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.bgp_as_a_service_client.list_bgp_as_a_services()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -54,7 +54,7 @@ class BGPAsAServicesTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('a039f0c4-b53a-492b-a5c5-fbdf046afcf4')
     def test_create_bgp_as_a_services(self):
         """test method for create bgp as a service objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_bgp_as_a_services()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -63,7 +63,7 @@ class BGPAsAServicesTest(rbac_base.BaseContrailTest):
     def test_show_bgp_as_a_service(self):
         """test method for show bgp as a service objects"""
         new_bgp = self._create_bgp_as_a_services()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.bgp_as_a_service_client.show_bgp_as_a_service(
                 new_bgp['uuid'])
 
@@ -73,7 +73,7 @@ class BGPAsAServicesTest(rbac_base.BaseContrailTest):
     def test_delete_bgp_as_a_service(self):
         """test method for delete bgp as a service objects"""
         new_bgp = self._create_bgp_as_a_services()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.bgp_as_a_service_client.delete_bgp_as_a_service(
                 new_bgp['uuid'])
 
@@ -83,7 +83,7 @@ class BGPAsAServicesTest(rbac_base.BaseContrailTest):
     def test_update_bgp_as_a_service(self):
         """test method for update bgp as a service objects"""
         new_bgp = self._create_bgp_as_a_services()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.bgp_as_a_service_client.update_bgp_as_a_service(
                 new_bgp['uuid'],
                 display_name=data_utils.rand_name('test-bgp'))

--- a/tungsten_tempest_plugin/tests/api/contrail/test_bgpvpn.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_bgpvpn.py
@@ -60,7 +60,7 @@ class BgpvpnTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('65afb5d5-52cb-484c-9e8e-42509be7dd77')
     def test_list_bgpvpns(self):
         """Test whether current role can list of bgpvpns."""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.contrail_client.list_bgpvpns()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -68,7 +68,7 @@ class BgpvpnTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('c3a7510c-c8d6-4736-9962-5c1aa032bf79')
     def test_create_bgpvpns(self):
         """Test whether current role can create bgpvpn."""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_bgpvpn()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -76,7 +76,7 @@ class BgpvpnTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('2fd05ca2-97d8-477c-aead-a881a2ba5e7e')
     def test_show_bgpvpn(self):
         """Test whether current role can get bgpvpn details."""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.contrail_client.show_bgpvpn(
                 self.bgpvpn_uuid)
 
@@ -86,7 +86,7 @@ class BgpvpnTest(rbac_base.BaseContrailTest):
     def test_delete_bgpvpn(self):
         """Test whether current role can delete bgpvpn details."""
         new_bgpvpn_uuid = self._create_bgpvpn()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.contrail_client.delete_bgpvpn(
                 new_bgpvpn_uuid)
 
@@ -95,7 +95,7 @@ class BgpvpnTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('ae734791-eaeb-4ca9-908a-59d0eac1a3c0')
     def test_update_bgpvpn(self):
         """Test whether current role can update bgpvpn."""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.contrail_client.update_bgpvpn(
                 self.bgpvpn_uuid,
                 display_name=data_utils.rand_name('test-bgpvpn'))

--- a/tungsten_tempest_plugin/tests/api/contrail/test_config_client.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_config_client.py
@@ -64,7 +64,7 @@ class ConfigNodeTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('b560e060-e4f0-45b0-93e2-55f0cb201e06')
     def test_list_config_nodes(self):
         """test method for list config node objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.config_client.list_config_nodes()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -72,7 +72,7 @@ class ConfigNodeTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('a8d20d0d-dc5a-4cae-87c5-7f6914c3701e')
     def test_create_config_nodes(self):
         """test method for create config node objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_config_node()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -82,7 +82,7 @@ class ConfigNodeTest(rbac_base.BaseContrailTest):
         """test method for delete config node objects"""
         config_node = self._create_config_node()
         config_node_uuid = config_node['config-node']['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.config_client.delete_config_node(
                 config_node_uuid)
 
@@ -93,7 +93,7 @@ class ConfigNodeTest(rbac_base.BaseContrailTest):
         """test method for show config node objects"""
         config_node = self._create_config_node()
         config_node_uuid = config_node['config-node']['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.config_client.show_config_node(config_node_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -104,7 +104,7 @@ class ConfigNodeTest(rbac_base.BaseContrailTest):
         config_node = self._create_config_node()
         config_node_uuid = config_node['config-node']['uuid']
         updated_name = data_utils.rand_name('new_config_node')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.config_client.update_config_node(
                 config_node_uuid, display_name=updated_name)
 
@@ -129,7 +129,7 @@ class ConfigRootTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('291b28ea-d0d8-47cd-ac76-1f980047cb76')
     def test_create_config_roots(self):
         """test method for create config root service objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_config_root()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -139,7 +139,7 @@ class ConfigRootTest(rbac_base.BaseContrailTest):
         """test method for delete config root service objects"""
         config_root = self._create_config_root()
         config_root_uuid = config_root['config-root']['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.config_client.delete_config_root(
                 config_root_uuid)
 
@@ -150,7 +150,7 @@ class ConfigRootTest(rbac_base.BaseContrailTest):
         """test method for show config root service objects"""
         config_root = self._create_config_root()
         config_root_uuid = config_root['config-root']['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.config_client.show_config_root(config_root_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -161,7 +161,7 @@ class ConfigRootTest(rbac_base.BaseContrailTest):
         config_root = self._create_config_root()
         config_root_uuid = config_root['config-root']['uuid']
         updated_name = data_utils.rand_name('new_config_root')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.config_client.update_config_root(
                 config_root_uuid, display_name=updated_name)
 
@@ -170,7 +170,7 @@ class ConfigRootTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('316e7425-8fb0-41b4-9080-a76697abbafa')
     def test_list_config_roots(self):
         """test method for list config root service objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.config_client.list_config_roots()
 
 
@@ -197,7 +197,7 @@ class GlobalSystemConfigTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('d1d189a7-14c1-49c5-b180-cd42ed2ca123')
     def test_list_global_system_configs(self):
         """test method for list global system config service objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.config_client.list_global_system_configs()
 
     @testtools.skipUnless(rbac_base.get_contail_version() < 5,
@@ -207,7 +207,7 @@ class GlobalSystemConfigTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('e0ba6a20-3e28-47ac-bf95-9a848fcee49a')
     def test_create_global_system_configs(self):
         """test method for create global system config service objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_global_system_config()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -216,7 +216,7 @@ class GlobalSystemConfigTest(rbac_base.BaseContrailTest):
     def test_show_global_system_config(self):
         if rbac_base.get_contail_version() < 5:
             new_config = self._create_global_system_config()
-            with self.rbac_utils.override_role(self):
+            with self.override_role():
                 self.config_client.show_global_system_config(
                     new_config['uuid'])
         else:
@@ -232,7 +232,7 @@ class GlobalSystemConfigTest(rbac_base.BaseContrailTest):
                                    "at least by default")
             for gsc in body:
                 if gsc['fq_name'][0] == 'default-global-system-config':
-                    with self.rbac_utils.override_role(self):
+                    with self.override_role():
                         self.config_client.show_global_system_config(
                             gsc['uuid'])
 
@@ -245,7 +245,7 @@ class GlobalSystemConfigTest(rbac_base.BaseContrailTest):
         """test method for update global system config service objects"""
         new_config = self._create_global_system_config()
         update_name = data_utils.rand_name('test')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.config_client.update_global_system_config(
                 new_config['uuid'],
                 display_name=update_name)
@@ -258,5 +258,5 @@ class GlobalSystemConfigTest(rbac_base.BaseContrailTest):
     def test_delete_global_system_config(self):
         """test method for delete global system config service objects"""
         new_config = self._create_global_system_config()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.config_client.delete_global_system_config(new_config['uuid'])

--- a/tungsten_tempest_plugin/tests/api/contrail/test_database.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_database.py
@@ -57,7 +57,7 @@ class ContrailDatabaseTest(rbac_base.BaseContrailTest):
     def test_list_database_nodes(self):
         """test method for list database objects"""
         self._create_database_node()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.db_client.list_database_nodes()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -66,7 +66,7 @@ class ContrailDatabaseTest(rbac_base.BaseContrailTest):
     def test_show_database_node(self):
         """test method for show database objects"""
         db_node = self._create_database_node()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.db_client.show_database_node(db_node['uuid'])
 
     @rbac_rule_validation.action(service="Contrail",
@@ -74,7 +74,7 @@ class ContrailDatabaseTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('b9aa9c6b-9381-44f0-94fb-e4523bf2a87e')
     def test_create_database_nodes(self):
         """test method for update database objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_database_node()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -85,7 +85,7 @@ class ContrailDatabaseTest(rbac_base.BaseContrailTest):
         db_node = self._create_database_node()
         db_node_id = db_node['uuid']
         display_name = data_utils.rand_name('DatabaseNew')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.db_client.update_database_node(
                 db_node_id=db_node_id,
                 display_name=display_name)
@@ -97,5 +97,5 @@ class ContrailDatabaseTest(rbac_base.BaseContrailTest):
         """test method for delete database objects"""
         db_node = self._create_database_node()
         db_node_id = db_node['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._delete_database_node(db_node_id)

--- a/tungsten_tempest_plugin/tests/api/contrail/test_discovery_service_assignment.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_discovery_service_assignment.py
@@ -47,7 +47,7 @@ class DiscoveryServiceAssignmentTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('9ac1e4ca-8983-403f-b644-7758935f2f36')
     def test_list_discovery_service(self):
         """test method for list discovery service assignment objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.dsa_client.list_ds_assignments()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -56,7 +56,7 @@ class DiscoveryServiceAssignmentTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('40ad1208-a039-4809-8516-41b4dfcbd00c')
     def test_create_discovery_service(self):
         """test method for create discovery service assignment objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_discovery_service_assignments()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -65,7 +65,7 @@ class DiscoveryServiceAssignmentTest(rbac_base.BaseContrailTest):
     def test_show_discovery_service(self):
         """test method for show discovery service assignment objects"""
         new_dsa = self._create_discovery_service_assignments()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.dsa_client.show_ds_assignment(new_dsa['uuid'])
 
     @rbac_rule_validation.action(service="Contrail",
@@ -75,7 +75,7 @@ class DiscoveryServiceAssignmentTest(rbac_base.BaseContrailTest):
         """test method for update discovery service assignment objects"""
         new_dsa = self._create_discovery_service_assignments()
         update_name = data_utils.rand_name('test')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.dsa_client.update_ds_assignment(
                 new_dsa['uuid'],
                 fq_name=new_dsa['fq_name'],
@@ -87,6 +87,6 @@ class DiscoveryServiceAssignmentTest(rbac_base.BaseContrailTest):
     def test_delete_discovery_service(self):
         """test method for delete discovery service assignment objects"""
         new_dsa = self._create_discovery_service_assignments()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.dsa_client.delete_ds_assignment(
                 new_dsa['uuid'])

--- a/tungsten_tempest_plugin/tests/api/contrail/test_domain.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_domain.py
@@ -56,7 +56,7 @@ class DomainContrailTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('fa02e27b-f661-4186-a522-69e8fcb6abf9')
     def test_list_domains(self):
         """test method for list domain objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.domain_client.list_domains()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -64,7 +64,7 @@ class DomainContrailTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('3f18be91-c37b-4e17-bf5e-b704d993f738')
     def test_create_domains(self):
         """test method for create domain objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_domains()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -73,7 +73,7 @@ class DomainContrailTest(rbac_base.BaseContrailTest):
     def test_show_domain(self):
         """test method for show domain objects"""
         domain_uuid = self._create_domains()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.domain_client.show_domain(domain_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -82,7 +82,7 @@ class DomainContrailTest(rbac_base.BaseContrailTest):
     def test_update_domain(self):
         """test method for update domain objects"""
         domain_uuid = self._create_domains()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._update_domain(domain_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -91,5 +91,5 @@ class DomainContrailTest(rbac_base.BaseContrailTest):
     def test_delete_domain(self):
         """test method for delete domain objects"""
         domain_uuid = self._create_domains()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.domain_client.delete_domain(domain_uuid)

--- a/tungsten_tempest_plugin/tests/api/contrail/test_dsa_rule.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_dsa_rule.py
@@ -60,7 +60,7 @@ class ContrailDSARuleTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('3227673b-96fc-4d26-ab0b-109347e9e9c2')
     def test_list_dsa_rules(self):
         """test method for list dsa rules objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.dsa_rule_client.list_dsa_rules()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -72,7 +72,7 @@ class ContrailDSARuleTest(rbac_base.BaseContrailTest):
         discovery_service_assignment = \
             self._create_discovery_service_assignments()['name']
         new_rule = self._create_dsa_rules(discovery_service_assignment)
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.dsa_rule_client.show_dsa_rule(new_rule['uuid'])
 
     @rbac_rule_validation.action(service="Contrail",
@@ -83,7 +83,7 @@ class ContrailDSARuleTest(rbac_base.BaseContrailTest):
         # create discover service assignment
         discovery_service_assignment = \
             self._create_discovery_service_assignments()['name']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_dsa_rules(discovery_service_assignment)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -96,7 +96,7 @@ class ContrailDSARuleTest(rbac_base.BaseContrailTest):
             self._create_discovery_service_assignments()['name']
         new_rule = self._create_dsa_rules(discovery_service_assignment)
         update_name = data_utils.rand_name('updated_rule')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.dsa_rule_client.update_dsa_rule(
                 new_rule['uuid'], display_name=update_name)
 
@@ -109,5 +109,5 @@ class ContrailDSARuleTest(rbac_base.BaseContrailTest):
         discovery_service_assignment = \
             self._create_discovery_service_assignments()['name']
         new_rule = self._create_dsa_rules(discovery_service_assignment)
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.dsa_rule_client.delete_dsa_rule(new_rule['uuid'])

--- a/tungsten_tempest_plugin/tests/api/contrail/test_fabric.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_fabric.py
@@ -51,7 +51,7 @@ class FabricContrailTest(rbac_base.BaseContrailTest):
 
         RBAC test for the Contrail list_fabrics policy
         """
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.contrail_client.list_fabrics()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -62,7 +62,7 @@ class FabricContrailTest(rbac_base.BaseContrailTest):
 
         RBAC test for the Contrail create_fabric policy
         """
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_fabric()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -73,7 +73,7 @@ class FabricContrailTest(rbac_base.BaseContrailTest):
 
         RBAC test for the Contrail show_fabric policy
         """
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.contrail_client.show_fabric(self.fabric_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -85,7 +85,7 @@ class FabricContrailTest(rbac_base.BaseContrailTest):
         RBAC test for the Contrail delete_fabric policy
         """
         fab_uuid = self._create_fabric()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.contrail_client.delete_fabric(fab_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -96,6 +96,6 @@ class FabricContrailTest(rbac_base.BaseContrailTest):
 
         RBAC test for the Contrail update_fabric policy
         """
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             put_body = {'display_name': data_utils.rand_name('update_fab')}
             self.contrail_client.update_fabric(self.fabric_uuid, **put_body)

--- a/tungsten_tempest_plugin/tests/api/contrail/test_fabric_namespaces.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_fabric_namespaces.py
@@ -73,7 +73,7 @@ class FabricNamespacesContrailTest(rbac_base.BaseContrailTest):
 
         RBAC test for the Contrail list_fabric_namespaces policy
         """
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.contrail_client.list_fabric_namespaces()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -84,7 +84,7 @@ class FabricNamespacesContrailTest(rbac_base.BaseContrailTest):
 
         RBAC test for the Contrail create_fabric_namespace policy
         """
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_fabric_namespace()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -95,7 +95,7 @@ class FabricNamespacesContrailTest(rbac_base.BaseContrailTest):
 
         RBAC test for the Contrail show_fabric_namespace policy
         """
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.contrail_client.show_fabric_namespace(
                 self.fabric_namespace_uuid)
 
@@ -108,7 +108,7 @@ class FabricNamespacesContrailTest(rbac_base.BaseContrailTest):
         RBAC test for the Contrail delete_fabric_namespace policy
         """
         ns_uuid = self._create_fabric_namespace()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.contrail_client.delete_fabric_namespace(ns_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -119,7 +119,7 @@ class FabricNamespacesContrailTest(rbac_base.BaseContrailTest):
 
         RBAC test for the Contrail update_fabric_namespace policy
         """
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             put_body = {'display_name': data_utils.rand_name('update_fns')}
             self.contrail_client.update_fabric_namespace(
                 self.fabric_namespace_uuid, **put_body)

--- a/tungsten_tempest_plugin/tests/api/contrail/test_floating_ip.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_floating_ip.py
@@ -110,7 +110,7 @@ class FloatingIpPoolTest(BaseFloatingIpTest):
     @decorators.idempotent_id('a83ca5e8-be4b-4161-869c-f981a724cf82')
     def test_create_floating_ip_pools(self):
         """test method for create floating IP pool objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_floating_ip_pool()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -119,7 +119,7 @@ class FloatingIpPoolTest(BaseFloatingIpTest):
     def test_list_floating_ip_pools(self):
         """test method for list floating IP pool objects"""
         self._create_floating_ip_pool()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.fip_client.list_floating_ip_pools()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -128,7 +128,7 @@ class FloatingIpPoolTest(BaseFloatingIpTest):
     def test_show_floating_ip_pool(self):
         """test method for show floating IP pool objects"""
         uuid = self._create_floating_ip_pool()['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.fip_client.show_floating_ip_pool(uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -137,7 +137,7 @@ class FloatingIpPoolTest(BaseFloatingIpTest):
     def test_update_floating_ip_pool(self):
         """test method for update floating IP pool objects"""
         uuid = self._create_floating_ip_pool()['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.fip_client.update_floating_ip_pool(
                 uuid,
                 display_name='rbac-fip-pool-new-name')
@@ -148,7 +148,7 @@ class FloatingIpPoolTest(BaseFloatingIpTest):
     def test_delete_floating_ip_pool(self):
         """test method for delete floating IP pool objects"""
         uuid = self._create_floating_ip_pool()['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.fip_client.delete_floating_ip_pool(uuid)
 
 
@@ -193,7 +193,7 @@ class FloatingIpTest(BaseFloatingIpTest):
     @decorators.idempotent_id('ff05f70f-9db9-43cb-a5ce-38cbbef2c430')
     def test_create_floating_ips(self):
         """test method for create floating IP objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_floating_ip()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -202,7 +202,7 @@ class FloatingIpTest(BaseFloatingIpTest):
     def test_list_floating_ips(self):
         """test method for list floating IP objects"""
         self._create_floating_ip()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.fip_client.list_floating_ips()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -211,7 +211,7 @@ class FloatingIpTest(BaseFloatingIpTest):
     def test_show_floating_ip(self):
         """test method for show floating IP objects"""
         uuid = self._create_floating_ip()['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.fip_client.show_floating_ip(uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -220,7 +220,7 @@ class FloatingIpTest(BaseFloatingIpTest):
     def test_update_floating_ip(self):
         """test method for update floating IP objects"""
         uuid = self._create_floating_ip()['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.fip_client.update_floating_ip(
                 uuid,
                 display_name='rbac-fip-new-name')
@@ -231,5 +231,5 @@ class FloatingIpTest(BaseFloatingIpTest):
     def test_delete_floating_ip(self):
         """test method for delete floating IP objects"""
         uuid = self._create_floating_ip()['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.fip_client.delete_floating_ip(uuid)

--- a/tungsten_tempest_plugin/tests/api/contrail/test_forwarding_class.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_forwarding_class.py
@@ -69,7 +69,7 @@ class ContrailForwardingClassTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('807a66fd-d4a4-472c-a13d-7ba590509e6e')
     def test_list_forwarding_classs(self):
         """test method for list forwarding classes objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.forwarding_class_client.list_forwarding_classs()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -81,7 +81,7 @@ class ContrailForwardingClassTest(rbac_base.BaseContrailTest):
         self.global_qos_config = \
             self._create_qos_global_configs()['name']
         new_fclass = self._create_forwarding_class(self.global_qos_config)
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.forwarding_class_client.show_forwarding_class(
                 new_fclass['uuid'])
 
@@ -93,7 +93,7 @@ class ContrailForwardingClassTest(rbac_base.BaseContrailTest):
         # Create a global qos config
         self.global_qos_config = \
             self._create_qos_global_configs()['name']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_forwarding_class(self.global_qos_config)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -106,7 +106,7 @@ class ContrailForwardingClassTest(rbac_base.BaseContrailTest):
             self._create_qos_global_configs()['name']
         new_fclass = self._create_forwarding_class(self.global_qos_config)
         update_name = data_utils.rand_name('updated_fclass')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.forwarding_class_client.update_forwarding_class(
                 new_fclass['uuid'], display_name=update_name)
 
@@ -119,6 +119,6 @@ class ContrailForwardingClassTest(rbac_base.BaseContrailTest):
         self.global_qos_config = \
             self._create_qos_global_configs()['name']
         new_fclass = self._create_forwarding_class(self.global_qos_config)
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.forwarding_class_client.delete_forwarding_class(
                 new_fclass['uuid'])

--- a/tungsten_tempest_plugin/tests/api/contrail/test_fqname_id.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_fqname_id.py
@@ -54,7 +54,7 @@ class FqnameIdTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('1fc1350b-3146-49bc-9af5-a61a98b55541')
     def test_fqname_to_id(self):
         """test method for fqname to id rules objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.fq_client.fqname_to_id(fq_name=self.network['fq_name'],
                                         type=self.type)
 
@@ -63,5 +63,5 @@ class FqnameIdTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('ecdd77d7-8508-4639-86cd-b97907b363ff')
     def test_id_to_fqname(self):
         """test method for id to fqname rules objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.fq_client.id_to_fqname(uuid=self.network['uuid'])

--- a/tungsten_tempest_plugin/tests/api/contrail/test_instance_ip.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_instance_ip.py
@@ -106,7 +106,7 @@ class InstanceIPTest(rbac_base.BaseContrailTest):
     def test_list_instance_ips(self):
         """test method for list instance IP objects"""
         self._create_instance_ip()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.iip_client.list_instance_ips()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -114,7 +114,7 @@ class InstanceIPTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('78f5cd4d-345d-4d87-8b8b-4d5d3fec4a12')
     def test_create_instance_ips(self):
         """test method for create instance IP objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_instance_ip()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -123,7 +123,7 @@ class InstanceIPTest(rbac_base.BaseContrailTest):
     def test_show_instance_ip(self):
         """test method for update instance IP objects"""
         uuid = self._create_instance_ip()['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.iip_client.show_instance_ip(uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -132,7 +132,7 @@ class InstanceIPTest(rbac_base.BaseContrailTest):
     def test_update_instance_ip(self):
         """test method for update instance IP objects"""
         uuid = self._create_instance_ip()['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.iip_client.update_instance_ip(
                 uuid,
                 display_name='rbac-iip-new-name')
@@ -143,5 +143,5 @@ class InstanceIPTest(rbac_base.BaseContrailTest):
     def test_delete_instance_ip(self):
         """test method for delete instance IP objects"""
         uuid = self._create_instance_ip()['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.iip_client.delete_instance_ip(uuid)

--- a/tungsten_tempest_plugin/tests/api/contrail/test_interfaces.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_interfaces.py
@@ -79,7 +79,7 @@ class InterfacesTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('c496a2b4-51b2-4674-a60e-483a315baccb')
     def test_list_physical_interfaces(self):
         """test method for list physical interfaces objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.interface_client.list_physical_interfaces()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -88,7 +88,7 @@ class InterfacesTest(rbac_base.BaseContrailTest):
     def test_create_physical_interfaces(self):
         """test method for create physical interfaces objects"""
         self._create_physical_router()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_physical_interface()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -102,7 +102,7 @@ class InterfacesTest(rbac_base.BaseContrailTest):
         response = self.interface_client.show_physical_interface(uuid)
         body = response['physical-interface']
         owner = body['perms2']['owner']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             change_access = {"owner": owner, "owner_access": 6, "share": [],
                              "global_access": 0}
             body = {"perms2": change_access}
@@ -116,7 +116,7 @@ class InterfacesTest(rbac_base.BaseContrailTest):
         """test method for delete physical interfaces objects"""
         self._create_physical_router()
         uuid = self._create_physical_interface()['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.interface_client.delete_physical_interface(uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -126,7 +126,7 @@ class InterfacesTest(rbac_base.BaseContrailTest):
         """test method for show physical interfaces objects"""
         self._create_physical_router()
         uuid = self._create_physical_interface()['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.interface_client.show_physical_interface(uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -134,7 +134,7 @@ class InterfacesTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('43ac3727-4a43-42d7-b52f-df75018915b9')
     def test_list_logical_interfaces(self):
         """test method for list physical interfaces objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.interface_client.list_logical_interfaces()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -144,7 +144,7 @@ class InterfacesTest(rbac_base.BaseContrailTest):
         """test method for create logical interfaces objects"""
         self._create_physical_router()
         self._create_physical_interface()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_logical_interface()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -159,7 +159,7 @@ class InterfacesTest(rbac_base.BaseContrailTest):
         response = self.interface_client.show_logical_interface(uuid)
         body = response['logical-interface']
         owner = body['perms2']['owner']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             change_access = {"owner": owner, "owner_access": 6, "share": [],
                              "global_access": 0}
             body = {"perms2": change_access}
@@ -174,7 +174,7 @@ class InterfacesTest(rbac_base.BaseContrailTest):
         self._create_physical_router()
         self._create_physical_interface()
         uuid = self._create_logical_interface()['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.interface_client.delete_logical_interface(uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -185,5 +185,5 @@ class InterfacesTest(rbac_base.BaseContrailTest):
         self._create_physical_router()
         self._create_physical_interface()
         uuid = self._create_logical_interface()['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.interface_client.show_logical_interface(uuid)

--- a/tungsten_tempest_plugin/tests/api/contrail/test_load_balancer.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_load_balancer.py
@@ -177,7 +177,7 @@ class LoadBalancerContrailTest(BaseLoadBalancerTest):
     @decorators.idempotent_id('5d840b6b-3974-4945-916f-dd53ba27e42f')
     def test_list_load_balancers(self):
         """test method for list load balancer objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.load_balancer_client.list_load_balancers()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -185,7 +185,7 @@ class LoadBalancerContrailTest(BaseLoadBalancerTest):
     @decorators.idempotent_id('6a18d506-0794-4eb9-a945-165bf146005d')
     def test_create_load_balancers(self):
         """test method for create load balancer objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_load_balancer()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -194,7 +194,7 @@ class LoadBalancerContrailTest(BaseLoadBalancerTest):
     def test_show_load_balancer(self):
         """test method for show load balancer objects"""
         lb_uuid = self._create_load_balancer()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.load_balancer_client.show_load_balancer(lb_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -203,7 +203,7 @@ class LoadBalancerContrailTest(BaseLoadBalancerTest):
     def test_update_load_balancer(self):
         """test method for update load balancer objects"""
         lb_uuid = self._create_load_balancer()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._update_load_balancer(lb_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -212,7 +212,7 @@ class LoadBalancerContrailTest(BaseLoadBalancerTest):
     def test_delete_load_balancer(self):
         """test method for delete load balancer objects"""
         lb_uuid = self._create_load_balancer()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.load_balancer_client.delete_load_balancer(lb_uuid)
 
 
@@ -226,7 +226,7 @@ class LoadBalancerHealthMonitorContrailTest(BaseLoadBalancerTest):
     @decorators.idempotent_id('3e3d8bdc-3621-4c5e-8130-1187f445a4e6')
     def test_list_lb_health_monitors(self):
         """test method for list load balancer health monitor objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.load_balancer_client.list_lb_healthmonitors()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -235,7 +235,7 @@ class LoadBalancerHealthMonitorContrailTest(BaseLoadBalancerTest):
     @decorators.idempotent_id('bddb93ad-d331-4bbc-bac6-2763cae4eb2c')
     def test_create_lb_health_monitors(self):
         """test method for create load balancer health monitor objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_load_balancer_health_monitor()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -244,7 +244,7 @@ class LoadBalancerHealthMonitorContrailTest(BaseLoadBalancerTest):
     def test_show_lb_health_monitor(self):
         """test method for show load balancer health monitor objects"""
         lb_hm_uuid = self._create_load_balancer_health_monitor()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.load_balancer_client.show_lb_healthmonitor(
                 lb_hm_uuid)
 
@@ -254,7 +254,7 @@ class LoadBalancerHealthMonitorContrailTest(BaseLoadBalancerTest):
     def test_update_lb_health_monitor(self):
         """test method for update load balancer health monitor objects"""
         lb_hm_uuid = self._create_load_balancer_health_monitor()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._update_load_balancer_health_monitor(lb_hm_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -263,7 +263,7 @@ class LoadBalancerHealthMonitorContrailTest(BaseLoadBalancerTest):
     def test_delete_lb_health_monitor(self):
         """test method for delete load balancer health monitor objects"""
         lb_hm_uuid = self._create_load_balancer_health_monitor()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.load_balancer_client.delete_lb_healthmonitor(
                 lb_hm_uuid)
 
@@ -276,7 +276,7 @@ class LoadBalancerListenerContrailTest(BaseLoadBalancerTest):
     @decorators.idempotent_id('7e02882f-0eab-41c2-b48a-bf71e083b912')
     def test_list_lb_listeners(self):
         """test method for list load balancer listener objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.load_balancer_client.list_load_balancer_listeners()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -284,7 +284,7 @@ class LoadBalancerListenerContrailTest(BaseLoadBalancerTest):
     @decorators.idempotent_id('0551de87-fa4c-463f-8968-ec6f2a6098d0')
     def test_create_lb_listeners(self):
         """test method for create load balancer listener objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_load_balancer_listener()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -293,7 +293,7 @@ class LoadBalancerListenerContrailTest(BaseLoadBalancerTest):
     def test_show_lb_listener(self):
         """test method for show load balancer listener objects"""
         lb_listener_uuid = self._create_load_balancer_listener()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.load_balancer_client.show_load_balancer_listener(
                 lb_listener_uuid)
 
@@ -303,7 +303,7 @@ class LoadBalancerListenerContrailTest(BaseLoadBalancerTest):
     def test_update_lb_listener(self):
         """test method for update load balancer listener objects"""
         lb_listener_uuid = self._create_load_balancer_listener()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._update_load_balancer_listener(lb_listener_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -312,7 +312,7 @@ class LoadBalancerListenerContrailTest(BaseLoadBalancerTest):
     def test_delete_lb_listener(self):
         """test method for delete load balancer listener objects"""
         lb_listener_uuid = self._create_load_balancer_listener()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.load_balancer_client.delete_load_balancer_listener(
                 lb_listener_uuid)
 
@@ -325,7 +325,7 @@ class LoadBalancerPoolContrailTest(BaseLoadBalancerTest):
     @decorators.idempotent_id('3d177a9e-7067-4e9e-b4e8-0acc5887dff0')
     def test_list_load_balancer_pools(self):
         """test method for list load balancer pool objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.load_balancer_client.list_load_balancer_pools()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -333,7 +333,7 @@ class LoadBalancerPoolContrailTest(BaseLoadBalancerTest):
     @decorators.idempotent_id('a52c6ec7-a996-4191-9a70-7879a211a711')
     def test_create_load_balancer_pools(self):
         """test method for create load balancer pool objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_load_balancer_pool()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -342,7 +342,7 @@ class LoadBalancerPoolContrailTest(BaseLoadBalancerTest):
     def test_show_load_balancer_pool(self):
         """test method for show load balancer pool objects"""
         lb_pool_uuid = self._create_load_balancer_pool()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.load_balancer_client.show_load_balancer_pool(lb_pool_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -351,7 +351,7 @@ class LoadBalancerPoolContrailTest(BaseLoadBalancerTest):
     def test_update_load_balancer_pool(self):
         """test method for update load balancer pool objects"""
         lb_pool_uuid = self._create_load_balancer_pool()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._update_load_balancer_pool(lb_pool_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -360,7 +360,7 @@ class LoadBalancerPoolContrailTest(BaseLoadBalancerTest):
     def test_delete_load_balancer_pool(self):
         """test method for delete load balancer pool objects"""
         lb_pool_uuid = self._create_load_balancer_pool()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.load_balancer_client.delete_load_balancer_pool(lb_pool_uuid)
 
 
@@ -372,7 +372,7 @@ class LoadBalancerMemberContrailTest(BaseLoadBalancerTest):
     @decorators.idempotent_id('b3c51463-8166-486a-a26e-0f7aeaa41e0f')
     def test_list_load_balancer_members(self):
         """test method for list load balancer member objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.load_balancer_client.list_load_balancer_members()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -380,7 +380,7 @@ class LoadBalancerMemberContrailTest(BaseLoadBalancerTest):
     @decorators.idempotent_id('ad60688f-7a20-4dd5-8229-4076d85b9d55')
     def test_create_lb_members(self):
         """test method for create load balancer member objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_load_balancer_member()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -389,7 +389,7 @@ class LoadBalancerMemberContrailTest(BaseLoadBalancerTest):
     def test_show_load_balancer_member(self):
         """test method for show load balancer member objects"""
         lb_member_uuid = self._create_load_balancer_member()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.load_balancer_client.show_load_balancer_member(lb_member_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -398,7 +398,7 @@ class LoadBalancerMemberContrailTest(BaseLoadBalancerTest):
     def test_update_lb_member(self):
         """test method for update load balancer member objects"""
         lb_member_uuid = self._create_load_balancer_member()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._update_load_balancer_member(lb_member_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -407,6 +407,6 @@ class LoadBalancerMemberContrailTest(BaseLoadBalancerTest):
     def test_delete_lb_member(self):
         """test method for delete load balancer member objects"""
         lb_member_uuid = self._create_load_balancer_member()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.load_balancer_client.delete_load_balancer_member(
                 lb_member_uuid)

--- a/tungsten_tempest_plugin/tests/api/contrail/test_namespace.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_namespace.py
@@ -56,7 +56,7 @@ class NamespaceContrailTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('e436390d-d669-4047-9838-421ea93e94be')
     def test_list_namespaces(self):
         """test method for list namespace objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.namespace_client.list_namespaces()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -64,7 +64,7 @@ class NamespaceContrailTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('503ae445-7e67-4db6-989a-af0b7f9a7e95')
     def test_create_namespaces(self):
         """test method for create namespace objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_namespace()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -73,7 +73,7 @@ class NamespaceContrailTest(rbac_base.BaseContrailTest):
     def test_show_namespace(self):
         """test method for show namespace objects"""
         namespace_uuid = self._create_namespace()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.namespace_client.show_namespace(namespace_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -82,7 +82,7 @@ class NamespaceContrailTest(rbac_base.BaseContrailTest):
     def test_update_namespace(self):
         """test method for update namespace objects"""
         namespace_uuid = self._create_namespace()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._update_namespace(namespace_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -91,5 +91,5 @@ class NamespaceContrailTest(rbac_base.BaseContrailTest):
     def test_delete_namespace(self):
         """test method for delete namespace objects"""
         namespace_uuid = self._create_namespace()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.namespace_client.delete_namespace(namespace_uuid)

--- a/tungsten_tempest_plugin/tests/api/contrail/test_network_ipams.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_network_ipams.py
@@ -46,7 +46,7 @@ class NetworkIpamsTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('9ee2c4d8-3209-4ef8-86e1-0ecea2d4c5f2')
     def test_list_network_ipams(self):
         """test method for list n/w ipam objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.network_ipams_client.list_network_ipams()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -54,7 +54,7 @@ class NetworkIpamsTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('ef2415ea-0810-413a-85a0-4508c9d7af91')
     def test_create_network_ipams(self):
         """test method for create n/w ipam objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_network_ipams()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -63,7 +63,7 @@ class NetworkIpamsTest(rbac_base.BaseContrailTest):
     def test_show_network_ipam(self):
         """test method for show n/w ipam objects"""
         new_ipam = self._create_network_ipams()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.network_ipams_client.show_network_ipam(new_ipam['uuid'])
 
     @rbac_rule_validation.action(service="Contrail",
@@ -72,7 +72,7 @@ class NetworkIpamsTest(rbac_base.BaseContrailTest):
     def test_delete_network_ipam(self):
         """test method for delete n/w ipam objects"""
         new_ipam = self._create_network_ipams()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.network_ipams_client.delete_network_ipam(new_ipam['uuid'])
 
     @rbac_rule_validation.action(service="Contrail",
@@ -81,7 +81,7 @@ class NetworkIpamsTest(rbac_base.BaseContrailTest):
     def test_update_network_ipam(self):
         """test method for update n/w ipam objects"""
         new_ipam = self._create_network_ipams()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.network_ipams_client.update_network_ipam(
                 new_ipam['uuid'],
                 display_name=data_utils.rand_name('test-ipam'))

--- a/tungsten_tempest_plugin/tests/api/contrail/test_network_policy.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_network_policy.py
@@ -58,7 +58,7 @@ class NetworkPolicyTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('fa2a28f3-a8bb-4908-95b9-1e11cf58b16f')
     def test_list_policys(self):
         """test method for list n/w policy objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.network_policy_client.list_network_policys()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -66,7 +66,7 @@ class NetworkPolicyTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('a30be228-afba-40c9-8678-ae020db68d79')
     def test_create_network_policys(self):
         """test method for create n/w policy objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_policy()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -75,7 +75,7 @@ class NetworkPolicyTest(rbac_base.BaseContrailTest):
     def test_show_network_policy(self):
         """test method for show n/w policy objects"""
         policy_uuid = self._create_policy()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.network_policy_client.show_network_policy(policy_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -84,7 +84,7 @@ class NetworkPolicyTest(rbac_base.BaseContrailTest):
     def test_update_network_policy(self):
         """test method for update n/w policy objects"""
         policy_uuid = self._create_policy()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._update_policy(policy_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -93,5 +93,5 @@ class NetworkPolicyTest(rbac_base.BaseContrailTest):
     def test_delete_network_policy(self):
         """test method for delete n/w policy objects"""
         policy_uuid = self._create_policy()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.network_policy_client.delete_network_policy(policy_uuid)

--- a/tungsten_tempest_plugin/tests/api/contrail/test_policy_management.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_policy_management.py
@@ -66,7 +66,7 @@ class PolicyManagementTest(rbac_base.BaseContrailTest):
 
         RBAC test for the Contrail create_policy_management policy
         """
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_policy_management()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -77,7 +77,7 @@ class PolicyManagementTest(rbac_base.BaseContrailTest):
 
         RBAC test for the Contrail list_policy_managements policy
         """
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.contrail_client.list_policy_managements()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -88,7 +88,7 @@ class PolicyManagementTest(rbac_base.BaseContrailTest):
 
         RBAC test for the Contrail show_policy_management policy
         """
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.contrail_client.\
                 show_policy_management(self.policy_management_uuid)
 
@@ -101,7 +101,7 @@ class PolicyManagementTest(rbac_base.BaseContrailTest):
         RBAC test for the Contrail delete_policy_management policy
         """
         obj_uuid = self._create_policy_management()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.contrail_client.\
                 delete_policy_management(obj_uuid)
 
@@ -116,6 +116,6 @@ class PolicyManagementTest(rbac_base.BaseContrailTest):
         put_body = {
             'display_name': data_utils.rand_name(
                 'update_policy_management')}
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.contrail_client.update_policy_management(
                 self.policy_management_uuid, **put_body)

--- a/tungsten_tempest_plugin/tests/api/contrail/test_port_tuple.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_port_tuple.py
@@ -74,7 +74,7 @@ class ContrailPortTupleTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('3789eef8-0e80-4057-b7b0-926655144beb')
     def test_list_port_tuples(self):
         """test method for list port tuple objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.port_tuple_client.list_port_tuples()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -83,7 +83,7 @@ class ContrailPortTupleTest(rbac_base.BaseContrailTest):
     def test_show_port_tuple(self):
         """test method for show port tuple objects"""
         new_tuple = self._create_port_tuple()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.port_tuple_client.show_port_tuple(new_tuple['uuid'])
 
     @rbac_rule_validation.action(service="Contrail",
@@ -91,7 +91,7 @@ class ContrailPortTupleTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('0e2283da-fe25-4204-b5b3-fef3c200d0c8')
     def test_create_port_tuples(self):
         """test method for create port tuple objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_port_tuple()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -101,7 +101,7 @@ class ContrailPortTupleTest(rbac_base.BaseContrailTest):
         """test method for update port tuple objects"""
         new_tuple = self._create_port_tuple()
         update_name = data_utils.rand_name('updated_tuple')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.port_tuple_client.update_port_tuple(
                 new_tuple['uuid'], display_name=update_name)
 
@@ -111,5 +111,5 @@ class ContrailPortTupleTest(rbac_base.BaseContrailTest):
     def test_delete_port_tuple(self):
         """test method for delete port tuple objects"""
         new_tuple = self._create_port_tuple()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.port_tuple_client.delete_port_tuple(new_tuple['uuid'])

--- a/tungsten_tempest_plugin/tests/api/contrail/test_project.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_project.py
@@ -57,7 +57,7 @@ class ProjectContrailTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('7db819fd-ceee-4a6b-9ad7-2e837c055bdd')
     def test_list_projects(self):
         """test method for list project objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.project_client.list_projects()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -65,7 +65,7 @@ class ProjectContrailTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('38b9b7a8-1568-417d-b0a3-e7adee88e4b9')
     def test_create_projects(self):
         """test method for create project objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_project()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -74,7 +74,7 @@ class ProjectContrailTest(rbac_base.BaseContrailTest):
     def test_show_project(self):
         """test method for show project objects"""
         project_uuid = self._create_project()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.project_client.show_project(project_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -83,7 +83,7 @@ class ProjectContrailTest(rbac_base.BaseContrailTest):
     def test_update_project(self):
         """test method for update project objects"""
         project_uuid = self._create_project()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._update_project(project_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -92,5 +92,5 @@ class ProjectContrailTest(rbac_base.BaseContrailTest):
     def test_delete_project(self):
         """test method for delete project objects"""
         project_uuid = self._create_project()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.project_client.delete_project(project_uuid)

--- a/tungsten_tempest_plugin/tests/api/contrail/test_qos_config.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_qos_config.py
@@ -53,7 +53,7 @@ class QosConfigContrailTest(rbac_base.BaseContrailTest):
     def test_list_qos_configs(self):
         """test method for list QoS config objects"""
         self._create_qos_configs()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.qos_client.list_qos_configs()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -61,7 +61,7 @@ class QosConfigContrailTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('031b4a27-22cd-4d93-938d-ba6d0f3163ba')
     def test_create_qos_configs(self):
         """test method for create QoS config objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_qos_configs()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -70,7 +70,7 @@ class QosConfigContrailTest(rbac_base.BaseContrailTest):
     def test_show_qos_config(self):
         """test method for show QoS config objects"""
         qos_config = self._create_qos_configs()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.qos_client.show_qos_config(qos_config['uuid'])
 
     @rbac_rule_validation.action(service="Contrail",
@@ -79,7 +79,7 @@ class QosConfigContrailTest(rbac_base.BaseContrailTest):
     def test_delete_qos_config(self):
         """test method for delete QoS config objects"""
         qos_config = self._create_qos_configs()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.qos_client.delete_qos_config(qos_config['uuid'])
 
     @rbac_rule_validation.action(service="Contrail",
@@ -89,7 +89,7 @@ class QosConfigContrailTest(rbac_base.BaseContrailTest):
         """test method for update QoS config objects"""
         qos_config = self._create_qos_configs()
         display_name = data_utils.rand_name('qos_config')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.qos_client.update_qos_config(
                 qos_config_id=qos_config['uuid'],
                 display_name=display_name)

--- a/tungsten_tempest_plugin/tests/api/contrail/test_qos_global_config.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_qos_global_config.py
@@ -58,7 +58,7 @@ class QosContrailTest(rbac_base.BaseContrailTest):
     def test_list_global_qos_configs(self):
         """test method for list global QoS objects"""
         self._create_qos_global_configs()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.qos_client.list_global_qos_configs()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -66,7 +66,7 @@ class QosContrailTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('d7da1ca0-7bf7-4d1b-982c-820cd37fe9fa')
     def test_create_global_qos_configs(self):
         """test method for create global QoS objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_qos_global_configs()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -75,7 +75,7 @@ class QosContrailTest(rbac_base.BaseContrailTest):
     def test_show_global_qos_config(self):
         """test method for show global QoS objects"""
         test = self._create_qos_global_configs()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.qos_client.show_global_qos_config(instance_id=test['uuid'])
 
     @rbac_rule_validation.action(service="Contrail",
@@ -85,7 +85,7 @@ class QosContrailTest(rbac_base.BaseContrailTest):
         """test method for update global QoS objects"""
         qos = self._create_qos_global_configs()
         display_name = data_utils.rand_name('qos_globale_config')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.qos_client.update_global_qos_config(
                 instance_id=qos['uuid'],
                 display_name=display_name)
@@ -96,5 +96,5 @@ class QosContrailTest(rbac_base.BaseContrailTest):
     def test_delete_global_qos_config(self):
         """test method for delete global QoS objects"""
         qos_global_config = self._create_qos_global_configs()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.qos_client.delete_global_qos_config(qos_global_config['uuid'])

--- a/tungsten_tempest_plugin/tests/api/contrail/test_qos_queue.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_qos_queue.py
@@ -55,7 +55,7 @@ class QosQueueContrailTest(rbac_base.BaseContrailTest):
     def test_list_qos_queues(self):
         """test method for listing QoS queues"""
         self._create_qos_queues()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.qos_client.list_qos_queues()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -63,7 +63,7 @@ class QosQueueContrailTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('d89c45f4-c83c-47b3-8720-7feffab4519c')
     def test_create_qos_queues(self):
         """test method for creating QoS queues"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_qos_queues()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -72,7 +72,7 @@ class QosQueueContrailTest(rbac_base.BaseContrailTest):
     def test_show_qos_queue(self):
         """test method for showing QoS queues"""
         qos_queue = self._create_qos_queues()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.qos_client.show_qos_queue(qos_queue['uuid'])
 
     @rbac_rule_validation.action(service="Contrail",
@@ -81,7 +81,7 @@ class QosQueueContrailTest(rbac_base.BaseContrailTest):
     def test_delete_qos_queue(self):
         """test method for deleting QoS queues"""
         qos_queue = self._create_qos_queues()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.qos_client.delete_qos_queue(qos_queue['uuid'])
 
     @rbac_rule_validation.action(service="Contrail",
@@ -91,7 +91,7 @@ class QosQueueContrailTest(rbac_base.BaseContrailTest):
         """test method for deleting QoS queues"""
         qos_queue = self._create_qos_queues()
         display_name = data_utils.rand_name('qos_queue')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.qos_client.update_qos_queue(
                 qos_queue_id=qos_queue['uuid'],
                 display_name=display_name)

--- a/tungsten_tempest_plugin/tests/api/contrail/test_route.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_route.py
@@ -55,7 +55,7 @@ class ContrailRouteTableTest(rbac_base.BaseContrailTest):
     def test_list_route_tables(self):
         """test method for list route table objects"""
         self._create_route_tables()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.route_client.list_route_tables()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -64,7 +64,7 @@ class ContrailRouteTableTest(rbac_base.BaseContrailTest):
     def test_show_route_table(self):
         """test method for show route table objects"""
         route_table = self._create_route_tables()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.route_client.show_route_table(route_table['uuid'])
 
     @rbac_rule_validation.action(service="Contrail",
@@ -72,7 +72,7 @@ class ContrailRouteTableTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('3fab8105-c0be-4c9e-be5f-d2dce4deb921')
     def test_create_route_tables(self):
         """test method for create route table objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_route_tables()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -82,7 +82,7 @@ class ContrailRouteTableTest(rbac_base.BaseContrailTest):
         """test method for update route table objects"""
         route_table = self._create_route_tables()
         display_name = data_utils.rand_name('RouteNew')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.route_client.update_route_table(
                 route_id=route_table['uuid'],
                 display_name=display_name)
@@ -93,7 +93,7 @@ class ContrailRouteTableTest(rbac_base.BaseContrailTest):
     def test_delete_route_table(self):
         """test method for delete route table objects"""
         route_table = self._create_route_tables()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._delete_route_table(route_table['uuid'])
 
 
@@ -123,7 +123,7 @@ class ContrailInterfaceRouteTableTest(rbac_base.BaseContrailTest):
     def test_list_interface_route(self):
         """test method for list route interface table objects"""
         self._create_interface_route_tables()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.route_client.list_interface_route_tables()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -132,7 +132,7 @@ class ContrailInterfaceRouteTableTest(rbac_base.BaseContrailTest):
     def test_show_interface_route(self):
         """test method for show route interface table objects"""
         interface_rte_table = self._create_interface_route_tables()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.route_client.show_interface_route_table(
                 interface_rte_table['uuid'])
 
@@ -141,7 +141,7 @@ class ContrailInterfaceRouteTableTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('b89ef437-4759-4c04-948b-d2ff9675ab07')
     def test_create_interface_route(self):
         """test method for create route interface table objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_interface_route_tables()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -151,7 +151,7 @@ class ContrailInterfaceRouteTableTest(rbac_base.BaseContrailTest):
         """test method for update route interface table objects"""
         interface_rte_table = self._create_interface_route_tables()
         display_name = data_utils.rand_name('InterfaceRouteNew')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.route_client.update_interface_route_table(
                 interface_route_id=interface_rte_table['uuid'],
                 display_name=display_name)
@@ -162,7 +162,7 @@ class ContrailInterfaceRouteTableTest(rbac_base.BaseContrailTest):
     def test_delete_interface_route(self):
         """test method for delete route interface table objects"""
         interface_rte_table = self._create_interface_route_tables()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._delete_interface_route_table(
                 interface_rte_table['uuid'])
 
@@ -193,7 +193,7 @@ class ContrailRouteTargetsTest(rbac_base.BaseContrailTest):
     def test_list_route_targets(self):
         """test method for list route target objects"""
         self._create_route_targets()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.route_client.list_route_targets()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -202,7 +202,7 @@ class ContrailRouteTargetsTest(rbac_base.BaseContrailTest):
     def test_show_route_target(self):
         """test method for show route target objects"""
         target = self._create_route_targets()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.route_client.show_route_target(target['uuid'])
 
     @rbac_rule_validation.action(service="Contrail",
@@ -210,7 +210,7 @@ class ContrailRouteTargetsTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('fcdb4ebc-b92d-49f2-88e9-68c93aec94be')
     def test_create_route_targets(self):
         """test method for create route target objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_route_targets()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -220,7 +220,7 @@ class ContrailRouteTargetsTest(rbac_base.BaseContrailTest):
         """test method for update route target objects"""
         target = self._create_route_targets()
         display_name = data_utils.rand_name('RouteTargetNew')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.route_client.update_route_target(
                 route_target_id=target['uuid'],
                 display_name=display_name)
@@ -231,7 +231,7 @@ class ContrailRouteTargetsTest(rbac_base.BaseContrailTest):
     def test_delete_route_target(self):
         """test method for delete route target objects"""
         target = self._create_route_targets()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._delete_route_target(target['uuid'])
 
 
@@ -260,7 +260,7 @@ class ContrailRouteAggregateTest(rbac_base.BaseContrailTest):
     def test_list_route_aggregates(self):
         """test method for list route aggregate objects"""
         self._create_route_aggregates()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.route_client.list_route_aggregates()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -269,7 +269,7 @@ class ContrailRouteAggregateTest(rbac_base.BaseContrailTest):
     def test_show_route_aggregate(self):
         """test method for show route aggregate objects"""
         route_aggr = self._create_route_aggregates()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.route_client.show_route_aggregate(
                 route_aggr['uuid'])
 
@@ -278,7 +278,7 @@ class ContrailRouteAggregateTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('7553a54f-e41c-4555-b745-a858c5a70690')
     def test_create_route_aggregates(self):
         """test method for create route aggregate objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_route_aggregates()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -288,7 +288,7 @@ class ContrailRouteAggregateTest(rbac_base.BaseContrailTest):
         """test method for update route aggregate objects"""
         route_aggr = self._create_route_aggregates()
         display_name = data_utils.rand_name('RouteAggregateNew')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.route_client.update_route_aggregate(
                 route_aggr_id=route_aggr['uuid'],
                 display_name=display_name)
@@ -300,5 +300,5 @@ class ContrailRouteAggregateTest(rbac_base.BaseContrailTest):
         """test method for delete route aggregate objects"""
         # Create aggregate
         route_aggr = self._create_route_aggregates()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._delete_route_aggregate(route_aggr['uuid'])

--- a/tungsten_tempest_plugin/tests/api/contrail/test_routers.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_routers.py
@@ -126,7 +126,7 @@ class BaseRouterTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('349ac042-b922-4727-9e1b-8f363ee343f3')
     def test_list_physical_routers(self):
         """test method for list physical router objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.router_client.list_physical_routers()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -134,7 +134,7 @@ class BaseRouterTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('d0b7449e-9037-4f9f-8c7e-9f364c95f18a')
     def test_create_physical_routers(self):
         """test method for create physical router objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_physical_router()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -143,7 +143,7 @@ class BaseRouterTest(rbac_base.BaseContrailTest):
     def test_show_physical_router(self):
         """test method for show physical router objects"""
         physical_router_uuid = self._create_physical_router()['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.router_client.show_physical_router(physical_router_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -153,7 +153,7 @@ class BaseRouterTest(rbac_base.BaseContrailTest):
         """test method for update physical router objects"""
         updated_fq_name = data_utils.rand_name('rbac-physical-router-new-name')
         physical_router_uuid = self._create_physical_router()['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.router_client.update_physical_router(
                 physical_router_uuid,
                 display_name=updated_fq_name)
@@ -164,7 +164,7 @@ class BaseRouterTest(rbac_base.BaseContrailTest):
     def test_delete_physical_router(self):
         """test method for delete physical router objects"""
         physical_router_uuid = self._create_physical_router()['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.router_client.delete_physical_router(physical_router_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -172,7 +172,7 @@ class BaseRouterTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('49bfb461-f99e-4585-b051-e20a3c937589')
     def test_list_bgp_routers(self):
         """test method for list bgp router objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.router_client.list_bgp_routers()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -182,7 +182,7 @@ class BaseRouterTest(rbac_base.BaseContrailTest):
         """test method for create bgp router objects"""
         # Create Routing Instance
         routing_instance = self._create_routing_instances()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_bgp_router(routing_instance)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -193,7 +193,7 @@ class BaseRouterTest(rbac_base.BaseContrailTest):
         # Create Routing Instance
         routing_instance = self._create_routing_instances()
         bgp_router_uuid = self._create_bgp_router(routing_instance)['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.router_client.show_bgp_router(bgp_router_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -205,7 +205,7 @@ class BaseRouterTest(rbac_base.BaseContrailTest):
         routing_instance = self._create_routing_instances()
         updated_fq_name = data_utils.rand_name('rbac-bgp-router-new-name')
         bgp_router_uuid = self._create_bgp_router(routing_instance)['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.router_client.update_bgp_router(
                 bgp_router_uuid,
                 display_name=updated_fq_name)
@@ -218,7 +218,7 @@ class BaseRouterTest(rbac_base.BaseContrailTest):
         # Create Routing Instance
         routing_instance = self._create_routing_instances()
         bgp_router_uuid = self._create_bgp_router(routing_instance)['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.router_client.delete_bgp_router(bgp_router_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -226,7 +226,7 @@ class BaseRouterTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('4af768d1-3cbe-4aff-bcbc-0e045cac3277')
     def test_list_global_vrouter_configs(self):
         """test method for list global vrouter config objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.router_client.list_global_vrouter_configs()
 
     @decorators.skip_because(bug="1792446")
@@ -243,7 +243,7 @@ class BaseRouterTest(rbac_base.BaseContrailTest):
         # linklocal metadata to go missing.
         # vrouter-agent will stuck in Init state with "No configuration for
         # self" error.
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_global_vrouter_config()
 
     @decorators.skip_because(bug="1792446")
@@ -262,7 +262,7 @@ class BaseRouterTest(rbac_base.BaseContrailTest):
         # self" error.
         global_vrouter_config_uuid = \
             self._create_global_vrouter_config()['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.router_client.show_global_vrouter_config(
                 global_vrouter_config_uuid)
 
@@ -284,7 +284,7 @@ class BaseRouterTest(rbac_base.BaseContrailTest):
             'rbac-global-vrouter-config-new-name')
         global_vrouter_config_uuid = \
             self._create_global_vrouter_config()['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.router_client.update_global_vrouter_config(
                 global_vrouter_config_uuid,
                 display_name=updated_fq_name)
@@ -302,7 +302,7 @@ class BaseRouterTest(rbac_base.BaseContrailTest):
 
         global_vrouter_config_uuid = \
             self._create_global_vrouter_config()['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.router_client.delete_global_vrouter_config(
                 global_vrouter_config_uuid)
 
@@ -311,7 +311,7 @@ class BaseRouterTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('674bf3de-a9e5-45c2-921b-b89db73a2abe')
     def test_list_logical_routers(self):
         """test method for list logical router objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.router_client.list_logical_routers()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -319,7 +319,7 @@ class BaseRouterTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('610f051b-8eba-4d3a-ba43-91386bfc0e52')
     def test_create_logical_routers(self):
         """test method for create logical router objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_logical_router()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -328,7 +328,7 @@ class BaseRouterTest(rbac_base.BaseContrailTest):
     def test_show_logical_router(self):
         """test method for show logical router objects"""
         logical_router_uuid = self._create_logical_router()['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.router_client.show_logical_router(logical_router_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -338,7 +338,7 @@ class BaseRouterTest(rbac_base.BaseContrailTest):
         """test method for update logical router objects"""
         updated_fq_name = data_utils.rand_name('rbac-logical-router-new-name')
         logical_router_uuid = self._create_logical_router()['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.router_client.update_logical_router(
                 logical_router_uuid,
                 display_name=updated_fq_name)
@@ -349,7 +349,7 @@ class BaseRouterTest(rbac_base.BaseContrailTest):
     def test_delete_logical_router(self):
         """test method for delete logical router objects"""
         logical_router_uuid = self._create_logical_router()['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.router_client.delete_logical_router(logical_router_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -357,7 +357,7 @@ class BaseRouterTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('604dc476-732e-4890-8665-a497360f5475')
     def test_list_virtual_routers(self):
         """test method for list virtual router objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.router_client.list_virtual_routers()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -365,7 +365,7 @@ class BaseRouterTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('114beb14-45c0-4714-a407-d160bb102022')
     def test_create_virtual_routers(self):
         """test method for create virtual router objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_virtual_router()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -374,7 +374,7 @@ class BaseRouterTest(rbac_base.BaseContrailTest):
     def test_show_virtual_router(self):
         """test method for show virtual router objects"""
         virtual_router_uuid = self._create_virtual_router()['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.router_client.show_virtual_router(virtual_router_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -384,7 +384,7 @@ class BaseRouterTest(rbac_base.BaseContrailTest):
         """test method for update virtual router objects"""
         updated_fq_name = data_utils.rand_name('rbac-virtual-router-new-name')
         virtual_router_uuid = self._create_virtual_router()['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.router_client.update_virtual_router(
                 virtual_router_uuid,
                 display_name=updated_fq_name)
@@ -395,5 +395,5 @@ class BaseRouterTest(rbac_base.BaseContrailTest):
     def test_delete_virtual_router(self):
         """test method for delete virtual router objects"""
         virtual_router_uuid = self._create_virtual_router()['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.router_client.delete_virtual_router(virtual_router_uuid)

--- a/tungsten_tempest_plugin/tests/api/contrail/test_routing.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_routing.py
@@ -62,7 +62,7 @@ class RoutingTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('054c56ba-76b2-4161-a702-40301d8de085')
     def test_list_routing_instances(self):
         """test method for list routing instance objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.routing_client.list_routing_instances()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -70,7 +70,7 @@ class RoutingTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('3d44a46b-5436-43a8-b2f7-8581f0f04dbc')
     def test_create_routing_instances(self):
         """test method for create routing instance objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_routing_instances()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -79,7 +79,7 @@ class RoutingTest(rbac_base.BaseContrailTest):
     def test_show_routing_instance(self):
         """test method for show routing instance objects"""
         new_instance = self._create_routing_instances()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.routing_client.show_routing_instance(new_instance['uuid'])
 
     @rbac_rule_validation.action(service="Contrail",
@@ -88,7 +88,7 @@ class RoutingTest(rbac_base.BaseContrailTest):
     def test_delete_routing_instance(self):
         """test method for delete routing instance objects"""
         new_instance = self._create_routing_instances()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.routing_client.delete_routing_instance(new_instance['uuid'])
 
     @rbac_rule_validation.action(service="Contrail",
@@ -97,7 +97,7 @@ class RoutingTest(rbac_base.BaseContrailTest):
     def test_update_routing_instance(self):
         """test method for update routing instance objects"""
         new_instance = self._create_routing_instances()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.routing_client.update_routing_instance(
                 new_instance['uuid'],
                 display_name=data_utils.rand_name('test-instance'))

--- a/tungsten_tempest_plugin/tests/api/contrail/test_routing_policy.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_routing_policy.py
@@ -58,7 +58,7 @@ class RoutingPolicyTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('fe25a306-bc4f-42b3-91ca-38df01e35345')
     def test_list_routing_policys(self):
         """test method for list routing policy objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.routing_policy_client.list_routing_policys()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -66,7 +66,7 @@ class RoutingPolicyTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('f8ca5e30-8bb3-410f-8618-8fdca70bda06')
     def test_create_routing_policys(self):
         """test method for create routing policy objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_routing_policy()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -75,7 +75,7 @@ class RoutingPolicyTest(rbac_base.BaseContrailTest):
     def test_show_routing_policy(self):
         """test method for show routing policy objects"""
         policy_uuid = self._create_routing_policy()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.routing_policy_client.show_routing_policy(policy_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -84,7 +84,7 @@ class RoutingPolicyTest(rbac_base.BaseContrailTest):
     def test_update_routing_policy(self):
         """test method for update routing policy objects"""
         policy_uuid = self._create_routing_policy()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._update_routing_policy(policy_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -93,5 +93,5 @@ class RoutingPolicyTest(rbac_base.BaseContrailTest):
     def test_delete_routing_policy(self):
         """test method for delete routing policy objects"""
         policy_uuid = self._create_routing_policy()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.routing_policy_client.delete_routing_policy(policy_uuid)

--- a/tungsten_tempest_plugin/tests/api/contrail/test_security_group.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_security_group.py
@@ -55,7 +55,7 @@ class ContrailSecurityGroupTest(rbac_base.BaseContrailTest):
     def test_list_security_groups(self):
         """test method for list security group objects"""
         self._create_security_groups()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.security_group_client.list_security_groups()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -65,7 +65,7 @@ class ContrailSecurityGroupTest(rbac_base.BaseContrailTest):
         """test method for show security group objects"""
         grp = self._create_security_groups()
         grp_id = grp['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.security_group_client.show_security_group(grp_id)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -75,7 +75,7 @@ class ContrailSecurityGroupTest(rbac_base.BaseContrailTest):
         """test method for delete security group objects"""
         grp = self._create_security_groups()
         grp_id = grp['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._delete_security_group(grp_id)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -83,7 +83,7 @@ class ContrailSecurityGroupTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('63a2ff14-7869-40a2-962a-d65752de5651')
     def test_create_security_groups(self):
         """test method for create security group objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_security_groups()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -94,7 +94,7 @@ class ContrailSecurityGroupTest(rbac_base.BaseContrailTest):
         grp = self._create_security_groups()
         grp_id = grp['uuid']
         display_name = data_utils.rand_name('securitygroupnew')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.security_group_client.update_security_group(
                 sec_group_id=grp_id,
                 display_name=display_name)

--- a/tungsten_tempest_plugin/tests/api/contrail/test_service_appliances.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_service_appliances.py
@@ -61,7 +61,7 @@ class ServiceAppliancesTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('6b5fc17c-34e6-4d21-a53e-a0dfe69afd31')
     def test_list_service_appliances(self):
         """test method for list service appliance objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.service_appliances_client.list_service_appliances()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -70,7 +70,7 @@ class ServiceAppliancesTest(rbac_base.BaseContrailTest):
     def test_create_service_appliances(self):
         """test method for create service appliance objects"""
         new_set = self._create_service_appliance_sets()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_service_appliances(new_set)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -80,7 +80,7 @@ class ServiceAppliancesTest(rbac_base.BaseContrailTest):
         """test method for show service appliance objects"""
         new_set = self._create_service_appliance_sets()
         new_appliance = self._create_service_appliances(new_set)
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.service_appliances_client.show_service_appliance(
                 new_appliance['uuid'])
 
@@ -92,7 +92,7 @@ class ServiceAppliancesTest(rbac_base.BaseContrailTest):
         new_set = self._create_service_appliance_sets()
         new_appliance = self._create_service_appliances(new_set)
         update_name = data_utils.rand_name('test')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.service_appliances_client.update_service_appliance(
                 new_appliance['uuid'],
                 display_name=update_name)
@@ -104,7 +104,7 @@ class ServiceAppliancesTest(rbac_base.BaseContrailTest):
         """test method for delete service appliance objects"""
         new_set = self._create_service_appliance_sets()
         new_appliance = self._create_service_appliances(new_set)
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.service_appliances_client.delete_service_appliance(
                 new_appliance['uuid'])
 
@@ -113,7 +113,7 @@ class ServiceAppliancesTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('c1e74da9-00b6-4c88-adda-2ce49094e570')
     def test_list_service_appl_sets(self):
         """test method for list service appliance sets objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.service_appliances_client.list_service_appliance_sets()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -121,7 +121,7 @@ class ServiceAppliancesTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('eb00d6cf-590f-41bf-8ee4-5be625d9cb93')
     def test_create_service_appl_sets(self):
         """test method for create service appliance sets objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_service_appliance_sets()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -130,7 +130,7 @@ class ServiceAppliancesTest(rbac_base.BaseContrailTest):
     def test_show_service_appl_set(self):
         """test method for show service appliance sets objects"""
         new_set = self._create_service_appliance_sets()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.service_appliances_client.show_service_appliance_set(
                 new_set['uuid'])
 
@@ -141,7 +141,7 @@ class ServiceAppliancesTest(rbac_base.BaseContrailTest):
         """test method for update service appliance sets objects"""
         new_set = self._create_service_appliance_sets()
         update_name = data_utils.rand_name('test')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.service_appliances_client.update_service_appliance_set(
                 new_set['uuid'],
                 display_name=update_name)
@@ -152,6 +152,6 @@ class ServiceAppliancesTest(rbac_base.BaseContrailTest):
     def test_delete_service_appl_set(self):
         """test method for delete service appliance sets objects"""
         new_set = self._create_service_appliance_sets()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.service_appliances_client.delete_service_appliance_set(
                 new_set['uuid'])

--- a/tungsten_tempest_plugin/tests/api/contrail/test_service_clients.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_service_clients.py
@@ -87,7 +87,7 @@ class ServiceClientsTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('841b1d32-4308-4fb6-852a-41bdd8c56c37')
     def test_list_service_templates(self):
         """test method for list service template objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.service_client.list_service_templates()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -95,7 +95,7 @@ class ServiceClientsTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('3f02d14a-31e2-4476-821f-87d0cc42d9fb')
     def test_create_service_templates(self):
         """test method for create service template objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_service_template()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -104,7 +104,7 @@ class ServiceClientsTest(rbac_base.BaseContrailTest):
     def test_show_service_template(self):
         """test method for show service template objects"""
         new_template = self._create_service_template()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.service_client.show_service_template(
                 new_template['uuid'])
 
@@ -115,7 +115,7 @@ class ServiceClientsTest(rbac_base.BaseContrailTest):
         """test method for update service template objects"""
         new_template = self._create_service_template()
         update_name = data_utils.rand_name('test')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.service_client.update_service_template(
                 new_template['uuid'],
                 display_name=update_name)
@@ -126,7 +126,7 @@ class ServiceClientsTest(rbac_base.BaseContrailTest):
     def test_delete_service_template(self):
         """test method for delete service template objects"""
         new_template = self._create_service_template()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.service_client.delete_service_template(
                 new_template['uuid'])
 
@@ -135,7 +135,7 @@ class ServiceClientsTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('5210d6ca-9a38-4b6b-b5b7-f836c3846079')
     def test_list_service_health_checks(self):
         """test method for list service health check objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.service_client.list_service_health_checks()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -143,7 +143,7 @@ class ServiceClientsTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('77716feb-0d05-4cfd-8a17-79cf0b19ed3c')
     def test_create_service_health(self):
         """test method for create service health check objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_service_health_check()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -152,7 +152,7 @@ class ServiceClientsTest(rbac_base.BaseContrailTest):
     def test_show_service_health(self):
         """test method for show service health check objects"""
         new_health_check = self._create_service_health_check()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.service_client.show_service_health_check(
                 new_health_check['uuid'])
 
@@ -163,7 +163,7 @@ class ServiceClientsTest(rbac_base.BaseContrailTest):
         """test method for update service health check objects"""
         new_health_check = self._create_service_health_check()
         update_name = data_utils.rand_name('test')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.service_client.update_service_health_check(
                 new_health_check['uuid'],
                 display_name=update_name)
@@ -174,7 +174,7 @@ class ServiceClientsTest(rbac_base.BaseContrailTest):
     def test_delete_service_health(self):
         """test method for delete service health check objects"""
         new_health_check = self._create_service_health_check()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.service_client.delete_service_health_check(
                 new_health_check['uuid'])
 
@@ -183,7 +183,7 @@ class ServiceClientsTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('1469c71e-f6f5-419f-9672-c3c67f879704')
     def test_create_service_instances(self):
         """test method for create service client objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_service_instance()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -192,7 +192,7 @@ class ServiceClientsTest(rbac_base.BaseContrailTest):
     def test_show_service_instance(self):
         """test method for show service client objects"""
         new_instance = self._create_service_instance()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.service_client.show_service_instance(
                 new_instance['uuid'])
 
@@ -202,7 +202,7 @@ class ServiceClientsTest(rbac_base.BaseContrailTest):
     def test_delete_service_instance(self):
         """test method for delete service client objects"""
         new_instance = self._create_service_instance()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.service_client.delete_service_instance(
                 new_instance['uuid'])
 
@@ -211,7 +211,7 @@ class ServiceClientsTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('da6016a3-a2a8-42a8-b064-c124c22fef6f')
     def test_list_service_instances(self):
         """test method for list service client objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.service_client.list_service_instances()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -221,7 +221,7 @@ class ServiceClientsTest(rbac_base.BaseContrailTest):
         """test method for update service client objects"""
         new_instance = self._create_service_instance()
         update_name = data_utils.rand_name('test')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.service_client.update_service_instance(
                 new_instance['uuid'],
                 display_name=update_name)

--- a/tungsten_tempest_plugin/tests/api/contrail/test_service_object.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_service_object.py
@@ -63,7 +63,7 @@ class ServiceObjectContrailTest(rbac_base.BaseContrailTest):
 
         RBAC test for the Contrail list_service_objects policy
         """
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.contrail_client.list_service_objects()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -74,7 +74,7 @@ class ServiceObjectContrailTest(rbac_base.BaseContrailTest):
 
         RBAC test for the Contrail create_service_object policy
         """
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_service_object()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -85,7 +85,7 @@ class ServiceObjectContrailTest(rbac_base.BaseContrailTest):
 
         RBAC test for the Contrail show_service_object policy
         """
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.contrail_client.show_service_object(self.service_object_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -97,7 +97,7 @@ class ServiceObjectContrailTest(rbac_base.BaseContrailTest):
         RBAC test for the Contrail delete_service_object policy
         """
         obj_uuid = self._create_service_object()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.contrail_client.delete_service_object(obj_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -111,6 +111,6 @@ class ServiceObjectContrailTest(rbac_base.BaseContrailTest):
         put_body = {
             'display_name': data_utils.rand_name(
                 'update_service_object')}
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.contrail_client.update_service_object(
                 self.service_object_uuid, **put_body)

--- a/tungsten_tempest_plugin/tests/api/contrail/test_subnet.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_subnet.py
@@ -55,7 +55,7 @@ class SubnetContrailTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('ddd1d9ae-cf2f-4a74-98ba-b0f481f27977')
     def test_list_subnets(self):
         """test method for list subnet objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.subnet_client.list_subnets()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -63,7 +63,7 @@ class SubnetContrailTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('ee0cb904-d162-44a4-b7b0-a7451f667ed5')
     def test_create_subnets(self):
         """test method for create subnet objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_subnet()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -72,7 +72,7 @@ class SubnetContrailTest(rbac_base.BaseContrailTest):
     def test_show_subnet(self):
         """test method for show subnet objects"""
         subnet_uuid = self._create_subnet()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.subnet_client.show_subnet(subnet_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -81,7 +81,7 @@ class SubnetContrailTest(rbac_base.BaseContrailTest):
     def test_update_subnet(self):
         """test method for update subnet objects"""
         subnet_uuid = self._create_subnet()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._update_subnet(subnet_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -90,5 +90,5 @@ class SubnetContrailTest(rbac_base.BaseContrailTest):
     def test_delete_subnet(self):
         """test method for delete subnet objects"""
         subnet_uuid = self._create_subnet()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.subnet_client.delete_subnet(subnet_uuid)

--- a/tungsten_tempest_plugin/tests/api/contrail/test_tag_type.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_tag_type.py
@@ -64,7 +64,7 @@ class ContrailTagTypeTest(rbac_base.BaseContrailTest):
 
         RBAC test for contrail list tag_type policy
         """
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.contrail_client.list_tag_types()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -75,7 +75,7 @@ class ContrailTagTypeTest(rbac_base.BaseContrailTest):
 
         RBAC test for contrail show tag_type policy
         """
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.contrail_client.show_tag_type(self.tag_type_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -86,7 +86,7 @@ class ContrailTagTypeTest(rbac_base.BaseContrailTest):
 
         RBAC test for contrail create tag_type policy
         """
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_tag_type()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -98,7 +98,7 @@ class ContrailTagTypeTest(rbac_base.BaseContrailTest):
         RBAC test for contrail update tag_type policy
         """
         update_name = data_utils.rand_name('new_name')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.contrail_client.update_tag_type(
                 self.tag_type_uuid, name=update_name)
 
@@ -111,5 +111,5 @@ class ContrailTagTypeTest(rbac_base.BaseContrailTest):
         RBAC test for contrail delete tag_type policy
         """
         new_tag_type_uuid = self._create_tag_type()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.contrail_client.delete_tag_type(new_tag_type_uuid)

--- a/tungsten_tempest_plugin/tests/api/contrail/test_virtual_dns.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_virtual_dns.py
@@ -76,7 +76,7 @@ class VirtualDNSTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('8401d690-afdf-4b6e-ad60-b9363a8cfb1d')
     def test_list_virtual_dns(self):
         """test method for list virtual dns objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.virtual_dns_client.list_virtual_dns()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -84,7 +84,7 @@ class VirtualDNSTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('a7dd2c9e-e1eb-4dc4-ac70-4d48a291a3bf')
     def test_create_virtual_dns(self):
         """test method for create virtual dns objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_virtual_dns()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -93,7 +93,7 @@ class VirtualDNSTest(rbac_base.BaseContrailTest):
     def test_show_virtual_dns(self):
         """test method for show virtual dns objects"""
         dns = self._create_virtual_dns()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.virtual_dns_client.show_virtual_dns(
                 dns['virtual-DNS']['uuid'])
 
@@ -103,7 +103,7 @@ class VirtualDNSTest(rbac_base.BaseContrailTest):
     def test_delete_virtual_dns(self):
         """test method for delete virtual dns objects"""
         dns = self._create_virtual_dns()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.virtual_dns_client.delete_virtual_dns(
                 dns['virtual-DNS']['uuid'])
 
@@ -117,7 +117,7 @@ class VirtualDNSTest(rbac_base.BaseContrailTest):
                             "default_ttl_seconds": 0,
                             "record_order": "fixed"}
         display_name = data_utils.rand_name('virtual-dns-updated')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.virtual_dns_client.update_virtual_dns(
                 dns_id=dns['virtual-DNS']['uuid'],
                 virtual_DNS_data=virtual_dns_data,
@@ -128,7 +128,7 @@ class VirtualDNSTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('e9103999-2f02-4f04-a8a0-906ca4fb394d')
     def test_list_virtual_dns_records(self):
         """test method for list virtual dns record objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.virtual_dns_client.list_virtual_dns_records()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -138,7 +138,7 @@ class VirtualDNSTest(rbac_base.BaseContrailTest):
         """test method for create virtual dns record objects"""
         # A virtual DNS is needed to create a record
         dns = self._create_virtual_dns()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_virtual_dns_record(dns)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -149,7 +149,7 @@ class VirtualDNSTest(rbac_base.BaseContrailTest):
         # A virtual DNS is needed to create a record
         dns = self._create_virtual_dns()
         dns_record = self._create_virtual_dns_record(dns)
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.virtual_dns_client.show_virtual_dns_record(
                 dns_record['virtual-DNS-record']['uuid'])
 
@@ -161,7 +161,7 @@ class VirtualDNSTest(rbac_base.BaseContrailTest):
         # A virtual DNS is needed to create a record
         dns = self._create_virtual_dns()
         dns_record = self._create_virtual_dns_record(dns)
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.virtual_dns_client.delete_virtual_dns_record(
                 dns_record['virtual-DNS-record']['uuid'])
 
@@ -179,7 +179,7 @@ class VirtualDNSTest(rbac_base.BaseContrailTest):
                                    "record_name": record_name,
                                    "record_class": "IN",
                                    "record_data": "1.1.1.1"}
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.virtual_dns_client.update_virtual_dns_record(
                 dns_record_id=dns_record['virtual-DNS-record']['uuid'],
                 virtual_DNS_record_data=virtual_dns_record_data)

--- a/tungsten_tempest_plugin/tests/api/contrail/test_virtual_ip.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_virtual_ip.py
@@ -56,7 +56,7 @@ class VirtualIPTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('92303eee-bd96-48bc-a02c-39950bd19a21')
     def test_list_virtual_ips(self):
         """test method for list virtual ip objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.virtual_ip_client.list_virtual_ips()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -64,7 +64,7 @@ class VirtualIPTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('e0070888-995d-46ab-91fc-db1412eba2f7')
     def test_create_virtual_ips(self):
         """test method for create virtual ip objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_virtual_ip()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -73,7 +73,7 @@ class VirtualIPTest(rbac_base.BaseContrailTest):
     def test_show_virtual_ip(self):
         """test method for show virtual ip objects"""
         virtual_ip_uuid = self._create_virtual_ip()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.virtual_ip_client.show_virtual_ip(virtual_ip_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -82,7 +82,7 @@ class VirtualIPTest(rbac_base.BaseContrailTest):
     def test_update_virtual_ip(self):
         """test method for update virtual ip objects"""
         virtual_ip_uuid = self._create_virtual_ip()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._update_virtual_ip(virtual_ip_uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -91,5 +91,5 @@ class VirtualIPTest(rbac_base.BaseContrailTest):
     def test_delete_virtual_ip(self):
         """test method for delete virtual ip objects"""
         virtual_ip_uuid = self._create_virtual_ip()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.virtual_ip_client.delete_virtual_ip(virtual_ip_uuid)

--- a/tungsten_tempest_plugin/tests/api/contrail/test_virtual_machines.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_virtual_machines.py
@@ -104,7 +104,7 @@ class VMContrailTest(rbac_base.BaseContrailTest):
     def test_list_vm_interfaces(self):
         """test method for list vm interfaces objects"""
         self._create_virual_machine_interface()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.vm_client.list_virtual_machine_interfaces()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -112,7 +112,7 @@ class VMContrailTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('d8a3a524-d61b-4bcb-8146-c5d4f308df8e')
     def test_add_vm_interfaces(self):
         """test method for add vm interfaces objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_virual_machine_interface()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -121,7 +121,7 @@ class VMContrailTest(rbac_base.BaseContrailTest):
     def test_show_vm_interface(self):
         """test method for show vm interfaces objects"""
         test = self._create_virual_machine_interface()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.vm_client.show_virtual_machine_interface(test['uuid'])
 
     @rbac_rule_validation.action(service="Contrail",
@@ -130,7 +130,7 @@ class VMContrailTest(rbac_base.BaseContrailTest):
     def test_delete_vm_interface(self):
         """test method for delete vm interfaces objects"""
         body = self._create_virual_machine_interface()
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.vm_client.delete_vm_interface(body['uuid'])
 
     @rbac_rule_validation.action(service="Contrail",
@@ -140,7 +140,7 @@ class VMContrailTest(rbac_base.BaseContrailTest):
         """test method for update vm interfaces objects"""
         virtual_machine = self._create_virual_machine_interface()
         display_name = data_utils.rand_name('new-vitual-machine-inf-name')
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.vm_client.update_vm_interface(
                 instance_id=virtual_machine['uuid'],
                 display_name=display_name)

--- a/tungsten_tempest_plugin/tests/api/contrail/test_virtual_networks.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/test_virtual_networks.py
@@ -70,7 +70,7 @@ class NetworksTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('375ebc8d-dc52-4d9c-877b-85aba35b1539')
     def test_list_virtual_networks(self):
         """test method for list vm network objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.vn_client.list_virtual_networks()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -78,7 +78,7 @@ class NetworksTest(rbac_base.BaseContrailTest):
     @decorators.idempotent_id('375ebc8d-dc52-4d9c-877b-96aba35b2530')
     def test_create_virtual_networks(self):
         """test method for create vm network objects"""
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self._create_virtual_network()
 
     @rbac_rule_validation.action(service="Contrail",
@@ -88,7 +88,7 @@ class NetworksTest(rbac_base.BaseContrailTest):
         """test method for update vm network objects"""
         # Create virtual network
         uuid = self._create_virtual_network()['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.vn_client.update_virtual_network(
                 uuid, router_external=False)
 
@@ -98,7 +98,7 @@ class NetworksTest(rbac_base.BaseContrailTest):
     def test_delete_virtual_network(self):
         """test method for delete vm network objects"""
         uuid = self._create_virtual_network()['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.vn_client.delete_virtual_network(uuid)
 
     @rbac_rule_validation.action(service="Contrail",
@@ -107,5 +107,5 @@ class NetworksTest(rbac_base.BaseContrailTest):
     def test_show_virtual_network(self):
         """test method for show vm network objects"""
         uuid = self._create_virtual_network()['uuid']
-        with self.rbac_utils.override_role(self):
+        with self.override_role():
             self.vn_client.show_virtual_network(uuid)


### PR DESCRIPTION
Lates changes]0] for Patrole breaks backward compatibility and now the code
which use `self.rbac_utils.override_role(self)` function is incorrect and needs
to be replace with `self.override_role()`. Also the `setup_rbac_utils` function
is no longer present.

[0] https://review.openstack.org/#/q/topic:rbac-utils-refactoring+(status:open+OR+status:merged)