### PR TITLE
Allow run Tungsten tests without tempest_roles=admin

### DIFF
--- a/tungsten_tempest_plugin/tests/api/contrail/rbac_base.py
+++ b/tungsten_tempest_plugin/tests/api/contrail/rbac_base.py
@@ -121,9 +121,6 @@ class BaseContrailTest(rbac_utils.RbacUtilsMixin, test.BaseTestCase):
         super(BaseContrailTest, cls).skip_checks()
         if not CONF.service_available.contrail:
             raise cls.skipException("Contrail support is required")
-        if CONF.auth.tempest_roles != ['admin']:
-            raise cls.skipException(
-                "%s skipped because tempest roles is not admin" % cls.__name__)
         if cls.required_contrail_version:
             cls.skip_if_contrail_version_less(cls.required_contrail_version)
 


### PR DESCRIPTION
Tungsten plugin is requiring admin role for the whole tempest, but some tempest tests (not related) are failing with admin role. Proposed solution is to override configured role for Tungsten tests only